### PR TITLE
Apply this template automatically for everyone using the common files

### DIFF
--- a/.common_files/stow/script/setup
+++ b/.common_files/stow/script/setup
@@ -10,3 +10,5 @@ if test -d "$personal_dir"; then
 fi
 
 $stow_cmd
+
+git config --global commit.template "~/.gitmessage"

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,13 @@
+# If applied, this commit will...
+
+Why is this change needed?
+--------------------------
+
+How does it address the issue?
+------------------------------
+
+Any links to any relevant tickets, articles or other resources?
+---------------------------------------------------------------
+
+# Was this co-authored?  Uncomment the following line, and make sure you use their official github email address
+# Co-authored-by: Tony Dewan tony.dewan@gmail.com


### PR DESCRIPTION
Why is this change needed?
--------------------------
As our projects get old, the value of great quality commit messages increases. In many cases we wish previous co-workers and previous versions of ourselves had spent more time explaining why they were doing what they were doing, instead of just explaining what the code does.Even things that are blindingly obvious now can be very unclear in a few years.

How does it address the issue?
------------------------------
It specifically prompts the user to answer 'why?' and 'how?'

As a bonus, this message is formatted in a way that makes github pull requests look good. That should save time and improve the quality of our PR communication.

Any links to any relevant tickets, articles or other resources?
---------------------------------------------------------------
https://thoughtbot.com/blog/better-commit-messages-with-a-gitmessage-template