### PR TITLE
Update rails console and server shortcuts

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -38,9 +38,9 @@ alias cuwip="cucumber ./features -t @wip"
 alias cufail="cucumber ./features -t @shouldfail"
 alias cuke="cucumber ./features"
 
-alias sc='script/console'
+alias sc='script/rails console'
 alias sct='RAILS_ENV="test" sc'
-alias ss='script/server'
+alias ss='script/rails server'
 
 alias ackp='ack --pager="less -r"'
 alias acki='ack -i'


### PR DESCRIPTION
Why is this change needed?
--------------------------
Many moons ago, Rails changed the correct way to start a console or server. These shortcuts were never updated and no longer work.

How does it address the issue?
------------------------------
Changes the command so it actually does what's intended.

Any links to any relevant tickets, articles or other resources?
---------------------------------------------------------------