### PR TITLE
Raise open file limit

### DIFF
--- a/.common_files/cf.Darwin.conf
+++ b/.common_files/cf.Darwin.conf
@@ -9,3 +9,5 @@ export CLICOLOR=1
 export LSCOLORS=ExFxCxDxBxegedabagacad
 export GOPATH=~/code/go
 export PATH=$PATH:$GOPATH/bin
+
+ulimit -n 2048


### PR DESCRIPTION
--------------------------
The default open file limit is too low for some of our tools to run properly, notably automation.  Also, it's 2019, `2**8` is absurdly low.  Even this is probably absurdly low.

How does it address the issue?
------------------------------
Raise the open file limit from `2**8` to `2**11`.

Any links to any relevant tickets, articles or other resources?
---------------------------------------------------------------
Reported in flowdock here: https://www.flowdock.com/app/expected-behavior/team-ops/threads/i5xint49xRwg-I87_iSFToofOJu
Reported in meat-space with many cursewords by various developers.

Co-authored-by: Joel Meador <joel@expectedbehavior.com>