### PR TITLE
Updates the commit template to include Alex

### DIFF
--- a/.gitmessage
+++ b/.gitmessage
@@ -18,3 +18,4 @@ Any links to any relevant tickets, articles or other resources?
 # Co-authored-by: Matthew Gordon <matt@expectedbehavior.com>
 # Co-authored-by: Jonathon Fruchte <jonathon@expectedbehavior.com>
 # Co-authored-by: David Ronk <david@expectedbehavior.com>
+# Co-authored-by: Alex Overbeck <alex@expectedbehavior.com>


### PR DESCRIPTION
Why is this change needed?
--------------------------
Alex wasn't on the Co-authored-by list. Adding him to the list makes it
easier for others to include him in their commit messages.

How does it address the issue?
------------------------------
It adds Alex to the list.