### PR TITLE
Print a warning message if open file limits are less than 200k

### DIFF
--- a/.common_files/cf.Darwin.conf
+++ b/.common_files/cf.Darwin.conf
@@ -14,3 +14,12 @@ export PATH=$PATH:$GOPATH/bin
 # https://gist.github.com/rockkoca/d3e402e7e23be503547699f33cf1a821
 ulimit -n 524288
 ulimit -u 4256
+
+if [[ $(launchctl limit maxfiles | awk '{ print $2 }') -lt 200000 ]]; then
+    echo
+    echo "WARNING"
+    echo "Your maxfile limit is less than 200,000"
+    echo "Review this gist for increasing"
+    echo "https://gist.github.com/rockkoca/d3e402e7e23be503547699f33cf1a821"
+    echo
+fi


### PR DESCRIPTION
Why is this change needed?
--------------------------
Some of the test files in Instrumental require more open files than that to run succesfully and the error you get if you don't have it is extremely obtuse (no error message, just stops running).

How does it address the issue?
------------------------------
Print a warning when you open a terminal and gives directions on how to fix the problem.

Any links to any relevant tickets, articles or other resources?
---------------------------------------------------------------

Co-authored-by: Alex Overbeck <alex@expectedbehavior.com>