### PR TITLE
silver searcher in emacs

### DIFF
--- a/.emacs.d/config.org
+++ b/.emacs.d/config.org
@@ -443,6 +443,11 @@ brew cask install font-fira-mono
     )
 #+END_SRC
 
+** Ag - The Silver Searcher
+If you want to use Projectile's search functions with ag
+
+(use-package ag)
+
 ** Projectile
 #+BEGIN_SRC emacs-lisp
   (use-package projectile

--- a/.emacs.d/config.org
+++ b/.emacs.d/config.org
@@ -541,9 +541,9 @@ blacklists a few modes, it belongs in Global.
 
 ** Org Roam
 Org Roam is a text based information management system using the
-Zettelkasten Method. If you don't know what that is, the simplest way
-to describe it is a personal wiki with tags that tracks and graphs
-links between nodes.
+Zettelkasten Method. If you haven't heard of it, think of it as a
+personal wiki with tags that tracks and graphs links between
+nodes. That's really underselling it.
 
 If you'd like to learn more, [[https://www.youtube.com/watch?v=AyhPmypHDEw&list=PLEoMzSkcN8oN3x3XaZQ-AXFKv52LZzjqD][System Crafters did a YouTube series]] that
 starts with the absolute basics and builds from there. You could
@@ -575,7 +575,6 @@ review and less of a user guide.
     :bind (
            ("C-c n f" . org-roam-node-find)
            ("C-c n i" . org-roam-node-insert)
-           ("C-c n I" . org-roam-node-insert-immediate)
            ("C-c n l" . org-roam-buffer-toggle)
            ("C-c n s" . org-roam-db-sync) ;; in case you delete a file outside emacs
            ("C-c n t" . org-roam-tag-add) ;; in case you delete a file outside emacs
@@ -587,13 +586,6 @@ review and less of a user guide.
     (org-roam-db-autosync-mode)
     )
 
-
-  (defun org-roam-node-insert-immediate (arg &rest args)
-    (interactive "P")
-    (let ((args (cons arg args))
-          (org-roam-capture-templates (list (append (car org-roam-capture-templates)
-                                                    '(:immediate-finish t)))))
-      (apply #'org-roam-node-insert args)))  
 
 #+END_SRC
 

--- a/script/setup
+++ b/script/setup
@@ -64,7 +64,7 @@ brew_install() {
 
 brew_cask_install() {
   setup_echo "Installing $1"
-  brew cask list $1 > /dev/null || brew cask install $1
+  brew list --cask $1 > /dev/null || brew install --cask $1
 }
 
 


### PR DESCRIPTION
Add Silver Searcher as an option for projectile searching

This is branched off of #19, because I can't live without OrgRoam. It makes the diff pretty useless right now, but you can tell what's happening if you just look at the most recent commit. 

