### PR TITLE
Remove the Emacs theme "melancholy"

### DIFF
--- a/.emacs.d/config.org
+++ b/.emacs.d/config.org
@@ -380,8 +380,6 @@ List of themes to install
     :defer t)
   (use-package github-theme
     :defer t)
-  (use-package melancholy-theme
-    :defer t)
   (use-package darkburn-theme
     :defer t)
   (use-package kaolin-themes


### PR DESCRIPTION
Why is this change needed?
--------------------------
It's no longer listed in MELPA

How does it address the issue?
------------------------------
Del Taco

Any links to any relevant tickets, articles or other resources?
---------------------------------------------------------------