### PR TITLE
Add a simple repeat function 

### DIFF
--- a/.bashrc
+++ b/.bashrc
@@ -174,6 +174,15 @@ vncvia() {
     fi
 }
 
+repeat() {
+    local i n
+    n=$1
+    shift
+    for ((i=1; i<=n; i++))
+        do "$@"
+    done
+}
+
 alias cd='pushd -n $PWD &> /dev/null; cd'
 # cf_cd() {
 #     pushd -n "$PWD" &> /dev/null


### PR DESCRIPTION
Add a simple repeat function that takes two arguments:
 - number of times to repeat
 - the command to repeat

Why is this change needed?
--------------------------
I do quick loops a LOT, and I believe that other people do as well. Might be nice to just have A Thing in the shell all the time.