### PR TITLE
Enable org roam dailies and the basic keymap

### DIFF
--- a/.emacs.d/config.org
+++ b/.emacs.d/config.org
@@ -596,7 +596,10 @@ review and less of a user guide.
            :map org-mode-map
            ("C-M-i" . completion-at-point)
            )
+    :bind-keymap
+    ("C-c n d" . org-roam-dailies-map)
     :config
+    (require 'org-roam-dailies)
     (org-roam-setup)
     (org-roam-db-autosync-mode)
   )

--- a/.emacs.d/config.org
+++ b/.emacs.d/config.org
@@ -600,6 +600,11 @@ review and less of a user guide.
     ("C-c n d" . org-roam-dailies-map)
     :config
     (require 'org-roam-dailies)
+    (setq org-roam-dailies-capture-templates
+          '(("d" "default" entry
+             "* %?"
+             :target (file+head "%<%Y-%m-%d>.org" ;; 2022-08-07 format for easy terminal usage
+                                "#+title: %<%B %d, %Y>\n")))) ;; August 7, 2022 in the title so it's easier for humans to read
     (org-roam-setup)
     (org-roam-db-autosync-mode)
   )


### PR DESCRIPTION
Why is this change needed?
--------------------------
This is an evolution in keeping a place for random scratch
information. I started with a simple append only text file. That
became hard to search when it became many thousands of
undifferentiated lines, so I tried using an org file. That led me to
having a heading for each day. That gets unwieldy when I'm working on
many different ideas on the same idea. I prefer to have as few
foldable layers as possible. Having a file per day was the obvious choice.

How does it address the issue?
------------------------------
Since org roam already provides this feature, it's incredibly
easy. The dailies feature is in a separate package, so I included
it. That package includes a keymap that follows the other org roam
patterns. It's got a bunch of stuff in it, but I'm mostly interested
in being able to quickly go to today, yesterday, and tomorrow.

today     - C-c n d d
yesterday - C-c n d y
tomorrow  - C-c n d t

Any links to any relevant tickets, articles or other resources?
---------------------------------------------------------------
https://3.basecamp.com/3093825/buckets/14355728/todos/5104237719
