### PR TITLE
Stop automatically indenting org text to the level of the node

### DIFF
--- a/.emacs.d/config.org
+++ b/.emacs.d/config.org
@@ -550,7 +550,9 @@ blacklists a few modes, it belongs in Global.
   (add-hook 'org-mode-hook 'auto-fill-mode)
 
   (let ((current-prefix-arg '(4)))
-      (setq org-startup-with-inline-images t))
+      (setq org-startup-with-inline-images t)
+      (setq org-adapt-indentation nil)
+      )
 
 #+END_SRC
 


### PR DESCRIPTION
Why is this change needed?
--------------------------
As previously configured, text beneath a node in org would automatically be indented to the level of the node, so it might look like

```
*
 foo
**
  foo
***
   foo
```
I think that's maddening

How does it address the issue?
------------------------------
The org-adapt-indentation controls that feature. I turned it off. It will now look like

```
*
foo
**
foo
***
foo
```

