### PR TITLE
Prevent asdf error before java is installed

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -77,8 +77,10 @@ test -e "${HOME}/.iterm2_shell_integration.bash" && source "${HOME}/.iterm2_shel
 
 if [[ -f "$(brew --prefix)/opt/asdf/libexec/asdf.sh" ]]; then
   source $(brew --prefix)/opt/asdf/libexec/asdf.sh
-  export JAVA_HOME=`asdf where java`
-  export PATH="$JAVA_HOME/bin:$PATH"
+  if asdf where java &> /dev/null; then
+    export JAVA_HOME=`asdf where java`
+    export PATH="$JAVA_HOME/bin:$PATH"
+  fi
 fi
 
 # this is busted: https://github.com/skotchpine/asdf-java/issues/46


### PR DESCRIPTION
Why is this change needed?
--------------------------
I believe I was getting an error message during computer setup because
the java plugin wasn't installed yet. This resulted in some weird text
in the PATH (an error message from asdf).

How does it address the issue?
------------------------------
Check if the asdf java plugin is installed before setting the JAVA_HOME.