### PR TITLE
Make it easier to manage ssh config files

### DIFF
--- a/.ssh/config
+++ b/.ssh/config
@@ -8,7 +8,6 @@ Host *
   UseKeychain yes
   AddKeysToAgent yes
 
-Host *
   UseRoaming no
 
 Include config.d/*.conf

--- a/.ssh/config
+++ b/.ssh/config
@@ -1,0 +1,15 @@
+# ControlPersist 4h
+# ControlMaster auto
+# ControlPath /tmp/ssh_mux_%h_%p_%r
+
+Host *
+  ServerAliveInterval 30
+
+  UseKeychain yes
+  AddKeysToAgent yes
+
+Host *
+  UseRoaming no
+
+Include config.d/*.conf
+


### PR DESCRIPTION
Why is this change needed?
--------------------------
We want some ssh config for EB, but people might have personal stuff as
well.

How does it address the issue?
------------------------------
Move to a config.d directory and include all files in that directory.
People can use stow to add personal configuration.