### PR TITLE
export a flag to disable objc fork safety. 

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -99,3 +99,5 @@ export PATH="$(brew --prefix)/Cellar/sbt@0.13/0.13.18_1/bin:$PATH"
 if [[ -f "$(brew --prefix)/bin/terraform" ]]; then
     complete -C $(brew --prefix)/bin/terraform terraform
 fi
+
+export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES


### PR DESCRIPTION
This is required in order to get forking to work properly in the docraptor tests. as things labeled 'unsafe' go, it is fairly safe. We have seen this before and this was the solution then, too. Read more: https://stackoverflow.com/questions/52671926/rails-may-have-been-in-progress-in-another-thread-when-fork-was-called

