### PR TITLE
Switch Jason's EDITOR to vscode

### DIFF
--- a/.common_files/cf.jason.conf
+++ b/.common_files/cf.jason.conf
@@ -13,7 +13,9 @@ export GPG_TTY=$(tty)
 
 alias lcw='long_command_wrap'
 
-export EDITOR="${HOME}/.common_files/bin/atom_wait"
+# This needs to be a script without arguments (instead of
+# `EDITOR="code --wait"`) because some utilities interpret it as a full command.
+export EDITOR="${HOME}/.common_files/bin/code_wait"
 
 export GOPATH=~/projects/go
 export PATH=$PATH:$GOPATH/bin

--- a/.common_files/stow/common-files-jason/.common_files/bin/code_wait
+++ b/.common_files/stow/common-files-jason/.common_files/bin/code_wait
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+code --wait "$@"


### PR DESCRIPTION
Why is this change needed?
--------------------------
VSCode is faster and seems to be getting more development than Atom.
I've been using it for awhile and have been enjoying it so I'll make it
offical.

How does it address the issue?
------------------------------
Switch the EDITOR variable to a newly added script to handle opening the
editor and waiting for the file to be closed.

This also adds a comment to help me waste less time next time trying a
simpler strategy. This avoids issues like:
```
$ EDITOR="code --wait" crontab -e
crontab: code --wait: No such file or directory
crontab: "code --wait" exited with status 1
```