### PR TITLE
Automatically open Dropbox

### DIFF
--- a/script/install/dropbox
+++ b/script/install/dropbox
@@ -7,6 +7,7 @@ source "$INSTALL_SCRIPTS_PATH/homebrew"
 
 install_dropbox() {
   brew_cask_install dropbox
+  open /Applications/Dropbox.app
   setup_echo "Now is the time to start syncing. After this, the script will start installing the default software and you'll be handsoff for a while. Hit enter when ready."
   read post_dropbox_install
 }


### PR DESCRIPTION
Why is this change needed?
--------------------------
We can make it clearer what should happen next, and speed things up for
the user a bit if we open Dropbox. This will then prompt them to login
and start syncing.

Did you complete all of the following?
--------------------------------------
- Run test suite?
- Add new tests?
- Consider security implications and practices?