### PR TITLE
Fix script/setup on initial run

### DIFF
--- a/script/install/homebrew
+++ b/script/install/homebrew
@@ -12,6 +12,11 @@ install_homebrew () {
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
   fi
 
+  # On first run brew won't be loaded yet
+  if [[ "$HOMEBREW_PREFIX" == "" ]]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+  fi
+
   setup_echo "Homebrew :: Installed"
 }
 


### PR DESCRIPTION
Why is this change needed?
--------------------------
On the first run we install homebrew, but we don't load it into the
shell. This causes the script to fail when it tries to use `brew`.

How does it address the issue?
------------------------------
Setup homebrew after installing it.

Did you complete all of the following?
--------------------------------------
- Run test suite?
- Add new tests?
- Consider security implications and practices?