### PR TITLE
Improve setup_secrets

### DIFF
--- a/script/setup_secrets
+++ b/script/setup_secrets
@@ -1,8 +1,10 @@
 #!/bin/bash
 
-default_dmg_path="${HOME}/Dropbox/secrets_$(hostname -s).dmg"
+set -e
 
-stored_secrets_path="${HOME}/Dropbox/.dropbox_secrets_path_$(hostname -s)"
+default_dmg_path="${HOME}/Documents/secrets/$(hostname -s)/secrets.sparsebundle"
+
+stored_secrets_path="${HOME}/Documents/secrets/$(hostname -s)/dropbox_secrets_path.txt"
 
 if [ -f "$stored_secrets_path" ]; then
   dmg_path=$(cat "$stored_secrets_path")
@@ -12,9 +14,10 @@ if [ ! -f "$dmg_path" ]; then
   # Prompt for dmg_path with default
   read -rp "Enter path to secrets dmg [$default_dmg_path]: " input
   dmg_path=${input:-$default_dmg_path}
+  mkdir -p "$(dirname "$stored_secrets_path")"
   echo "$dmg_path" > "$stored_secrets_path"
 
-  hdiutil create -size 100m -encryption -type UDIF -fs APFS -volname secrets "$dmg_path"
+  hdiutil create -size 16t -encryption -type SPARSEBUNDLE -fs APFS -volname secrets "$dmg_path"
 fi
 
 # Mount the dmg if not mounted

--- a/script/setup_secrets
+++ b/script/setup_secrets
@@ -2,9 +2,9 @@
 
 set -e
 
-default_dmg_path="${HOME}/Documents/secrets/$(hostname -s)/secrets.sparsebundle"
+default_dmg_path="${HOME}/Dropbox/secrets/$(hostname -s)/secrets.sparsebundle"
 
-stored_secrets_path="${HOME}/Documents/secrets/$(hostname -s)/dropbox_secrets_path.txt"
+stored_secrets_path="${HOME}/Dropbox/secrets/$(hostname -s)/dropbox_secrets_path.txt"
 
 if [ -f "$stored_secrets_path" ]; then
   dmg_path=$(cat "$stored_secrets_path")


### PR DESCRIPTION
Why is this change needed?
--------------------------
The previous implimentation stored the path of the image in
`Dropbox/.dropbox_secrets_path_$(hostname -s)` which annoyingly wasn't
visible in the dropbox.com UI. We move it to a more visible location.

We also collect everything under `Documents/secrets/$(hostname -s)` to
keep things organized instead of having many files in the dropbox root.

I was curious about moving more stuff into the secrets volume so I
chatted with GPT about the sparse disk options and it mentioned
sparsebundles having better network reslience. I'll give it a shot and
see.

I also moved the secrets volume to iCloud `Documents` because so it
should automatically sync to a new laptop when I log in with my iCloud
account.

Did you complete all of the following?
--------------------------------------
- Run test suite?
- Add new tests?
- Consider security implications and practices?