### PR TITLE
Fix brewfile issue

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,7 +1,7 @@
 cask_args appdir: '/Applications'
 tap 'homebrew/cask'
 
-brewfile_root_dir = File.expand_path(File.dirname(__FILE__))
+brewfile_root_dir = Dir.home
 brewfile_dir      = File.join(brewfile_root_dir, ".brewfiles")
 current_username  = `whoami`.chomp
 personal_brewfile = File.join(brewfile_dir, "personal.Brewfile.#{current_username}")


### PR DESCRIPTION
Why is this change needed?
--------------------------
`File.dirname(__FILE__)` was returning `~/.dotfiles` instead of the
user's home directory. This cause us to not find user brewfiles that
were linked through stow.

How does it address the issue?
------------------------------
Look for `.brewfiles` in the user's home directory.

Did you complete all of the following?
--------------------------------------
- Run test suite?
- Add new tests?
- Consider security implications and practices?