### PR TITLE
Add Firefox ESR to the path if it is installed

### DIFF
--- a/.bash_profile
+++ b/.bash_profile
@@ -101,3 +101,7 @@ if [[ -f "$(brew --prefix)/bin/terraform" ]]; then
 fi
 
 export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES
+
+if [ -d "/Applications/Firefox.app/Contents/MacOS" ]; then
+    export PATH="/Applications/Firefox.app/Contents/MacOS:$PATH"
+fi


### PR DESCRIPTION
Why is this change needed?
--------------------------
We use Firefox ESR in some projects because it works with the latest version of geckodrivers[1]

How does it address the issue?
------------------------------
Check to see if it is installed at the place that Homebrew usually install it. If it is installed, add it to the path.

Any links to any relevant tickets, articles, or other resources?
 --------------------------------------------------------------- 

1 - https://firefox-source-docs.mozilla.org/testing/geckodriver/Support.html

Did you complete all of the following?
--------------------------------------
- Run test suite? -
- Add new tests? -
- Consider security implications and practices? Y